### PR TITLE
Add time option to append relative time to tweets

### DIFF
--- a/src/jquery.twitter.js
+++ b/src/jquery.twitter.js
@@ -21,6 +21,27 @@ var linkify = linkify || function() {};
     return str.replace(/[#]+[a-z0-9-_]+/ig, function( tag ) {
       return tag.link("http://search.twitter.com/search?q="+tag.replace("#","%23"));
     });
+  },
+  relativeTime = function( timeValue ) {
+    var parsedDate = Date.parse( timeValue ),
+        relativeTo = arguments.length > 1 ? arguments[1] : new Date(),
+        delta = parseInt( ( relativeTo.getTime() - parsedDate ) / 1000, 10 );
+    delta += ( relativeTo.getTimezoneOffset() * 60 );
+    if ( delta < 60 ) {
+      return 'less than a minute ago';
+    } else if ( delta < 120 ) {
+      return 'about a minute ago';
+    } else if ( delta < ( 60 * 60 ) ) {
+      return ( parseInt( delta / 60, 10 ) ).toString() + ' minutes ago';
+    } else if ( delta < ( 120 * 60 ) ) {
+      return 'about an hour ago';
+    } else if ( delta < ( 24 * 60 * 60 ) ) {
+      return 'about ' + ( parseInt(delta / 3600, 10 ) ).toString() + ' hours ago';
+    } else if ( delta < ( 48 * 60 * 60 ) ) {
+      return '1 day ago';
+    } else {
+      return ( parseInt( delta / 86400, 10 ) ).toString() + ' days ago';
+    }
   };
 
   $.twitter = function (options, callback) {
@@ -134,13 +155,22 @@ var linkify = linkify || function() {};
               }));
             }
 
-            // Make the tweet text, and append it to the $tweet, then to the parent
+            // Make the tweet text, and append it to the $tweet
             $tweet.append($("<span>", {
               "class": "content",
               html: "<a href='http://twitter.com/" + tweet.from_user + "'>@" + tweet.from_user + "</a>: " + mention(hashtags(linkify(tweet.text)))
-            }))
+            }));
+
+            // Append time to $tweet
+            if( query.time === true ) {
+              $tweet.append($("<span>", {
+                "class": "time",
+                html: " <a href='http://twitter.com/" + tweet.from_user + "/status/" + tweet.id_str + "'>" + relativeTime(tweet.created_at) + "</a>"
+              }));
+            }
+
             // Append tweet to the $tweets ul
-            .appendTo($tweets);
+            $tweet.appendTo($tweets);
 
             // Count up our counter variable
             limitInt++;

--- a/test/jquery.twitter_test.js
+++ b/test/jquery.twitter_test.js
@@ -39,16 +39,22 @@
     // Temporarily replace $.twitter with a mock version that returns a pre-defined result
     $.oTwitter = $.twitter;
     $.twitter = function( options, callback ) {
-      var tweets = {
+      var date = new Date(),
+      tweets = {
         "results" : [{
+          "created_at": null,
+          "id_str": "123456",
           "from_user": "mediatemple",
           "text": "This text contains a @mention and a #hashtag"
         }]
       };
-      callback( tweets, {}, null );
+      // Add timezone offset of test machine to date to ensure we get a relative time of "less than a minute ago"
+      date.setSeconds( date.getSeconds() + date.getTimezoneOffset() * 60 );
+      tweets.results[0].created_at = date.toGMTString();
+      callback( tweets, options, null );
     };
 
-    $("#testlist6").twitter({ from: "mediatemple" });
+    $("#testlist6").twitter({ from: "mediatemple", time: true });
 
     // Replace original $.twitter function
     $.twitter = $.oTwitter;
@@ -142,6 +148,8 @@
       ok( $("#testlist6").children().find('a[href="http://twitter.com/mention"]').length, "Make sure @mentions are linked" );
 
       ok( $("#testlist6").children().find('a[href="http://search.twitter.com/search?q=%23hashtag"]').length, "Make sure #hashtags are linked" );
+
+      equal( $("#testlist6").find("span.time > a").text(), "less than a minute ago", "Make sure time is there" );
 
     });
     test("Test a few of the cases for the object style signature", function() {


### PR DESCRIPTION
Add a `time` option, which appends a relative time to tweets, e.g.
"a minute ago", "about 8 hours ago", "2 days ago". The time is
also a link to the actual tweet.

Inspired by and code borrowed from [Christian Heilmann's twitterbadge](http://christianheilmann.com/2008/04/11/example-of-an-unobtrusive-lazy-loading-badge-using-the-twitter-api/)
